### PR TITLE
chore: bump version to publish deprecation notice

### DIFF
--- a/Nowsecure/task.json
+++ b/Nowsecure/task.json
@@ -13,7 +13,7 @@
     "version": {
         "Major": 1,
         "Minor": 0,
-        "Patch": 20
+        "Patch": 21
     },
     "demands": [
         "java"

--- a/vss-extension.json
+++ b/vss-extension.json
@@ -3,7 +3,7 @@
     "id": "azure-nowsecure-auto-security-test-qa",
     "name": "azure-nowsecure-auto-security-test",
     "description": "Azure Extension for NowSecure Auto Security Test",
-    "version": "1.0.20",
+    "version": "1.0.21",
     "publisher": "qa-nowsecure",
     "targets": [
         {


### PR DESCRIPTION
All azure extension updates must increment the task and vss-extension versions